### PR TITLE
Check that `wp_print_font_faces()` exists

### DIFF
--- a/font-face-tester.php
+++ b/font-face-tester.php
@@ -8,6 +8,10 @@
  * Version: 1.0.0
  */
 
+if ( ! function_exists( 'wp_print_font_faces' ) ) {
+	return;
+}
+
 add_action( 'wp_head', 'fontfacetester_print_fonts', 50 );
 add_action( 'admin_print_styles', 'fontfacetester_print_fonts', 50 );
 function fontfacetester_print_fonts() {


### PR DESCRIPTION
This would help prevent a fatal error should the plugin remain active when reverting the PR or running on a version of WP < 6.4.

Full disclosure: Code provided as-is from Copilot 🧑‍✈️ 100% time saved 😂 